### PR TITLE
Add placeholder third_party directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 build/
 dist/
 package-lock.json
-third_party/
+third_party/*
+!third_party/README.md
 mqtt_opt.md
 local_dev/

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,17 @@
+This directory contains third-party dependencies for the project.
+
+The recommended approach is to clone the required libraries as git submodules:
+
+```
+git submodule update --init --recursive
+```
+
+If network access is not available, you may manually download the following
+projects and place them here:
+
+- libuv -> `third_party/libuv`
+- libwebsockets -> `third_party/libwebsockets`
+- nlohmann/json -> `third_party/nlohmann`
+
+Alternatively, configure CMake to use system-installed versions by enabling the
+`USE_SYSTEM_LIBUV` and `USE_SYSTEM_LIBWEBSOCKETS` options.


### PR DESCRIPTION
## Summary
- track a placeholder third_party directory
- allow a README file to be committed even though the folder is ignored

## Testing
- `cmake .. -DBUILD_TESTS=ON` *(fails: `third_party/libuv` and `third_party/libwebsockets` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afb61c088832abeff2f2b029d07e2